### PR TITLE
Add contexts on event tracking

### DIFF
--- a/lib/fluent/plugin/out_snowplow.rb
+++ b/lib/fluent/plugin/out_snowplow.rb
@@ -47,10 +47,15 @@ class Fluent::SomeOutput < Fluent::TimeSlicedOutput
       message = JSON.parse record['message']
       true_timestamp = record['true_timestamp']
       application = record['application']
+      contexts = JSON.parse record['contexts']
       tracker = tracker_for(application)
 
+      contexts = contexts.map do |context|
+        SnowplowTracker::SelfDescribingJson.new(context['schema'], context['message'])
+      end
+
       self_describing_json = SnowplowTracker::SelfDescribingJson.new(schema, message)
-      tracker.track_self_describing_event(self_describing_json, nil, SnowplowTracker::TrueTimestamp.new(true_timestamp.to_i))
+      tracker.track_self_describing_event(self_describing_json, contexts, SnowplowTracker::TrueTimestamp.new(true_timestamp.to_i))
     end
 
     tracker.flush

--- a/lib/fluent/plugin/out_snowplow.rb
+++ b/lib/fluent/plugin/out_snowplow.rb
@@ -47,11 +47,14 @@ class Fluent::SomeOutput < Fluent::TimeSlicedOutput
       message = JSON.parse record['message']
       true_timestamp = record['true_timestamp']
       application = record['application']
-      contexts = JSON.parse record['contexts']
+      contexts = JSON.parse record.fetch('contexts', "[]")
       tracker = tracker_for(application)
 
       contexts = contexts.map do |context|
-        SnowplowTracker::SelfDescribingJson.new(context['schema'], context['message'])
+        context_schema = context['schema']
+        context_message = JSON.parse context['message']
+
+        SnowplowTracker::SelfDescribingJson.new(context_schema, context_message)
       end
 
       self_describing_json = SnowplowTracker::SelfDescribingJson.new(schema, message)

--- a/lib/fluent/plugin/out_snowplow.rb
+++ b/lib/fluent/plugin/out_snowplow.rb
@@ -52,7 +52,7 @@ class Fluent::SomeOutput < Fluent::TimeSlicedOutput
 
       contexts = contexts.map do |context|
         context_schema = context['schema']
-        context_message = JSON.parse context['message']
+        context_message = context['message']
 
         SnowplowTracker::SelfDescribingJson.new(context_schema, context_message)
       end

--- a/lib/fluent/plugin/snowplow/version.rb
+++ b/lib/fluent/plugin/snowplow/version.rb
@@ -1,7 +1,7 @@
 module Fluent
   module Plugin
     module Snowplow
-      VERSION = "0.1.3"
+      VERSION = "0.2.3"
     end
   end
 end


### PR DESCRIPTION
This change add the possibility of adding an array of contexts when reading a event from the logstash(read more about it [here](https://github.com/snowplow/snowplow/wiki/Ruby-Tracker#412-optional-context-argument)).

Example without context:
```
{
  "message": "{\"a\":1,\"b\":2,\"c\":3}",
  "application": "App",
  "schema": "some_schema_here",
  "true_timestamp": "1526583990857",
  "contexts": "[]",
  "@timestamp": "2018-05-17T19:06:30.857Z",
  "@version": "1",
  "severity": "INFO",
  "host": "Dominiks.local"
}
```

Same example with context:
```
{
  "message": "{\"a\":1,\"b\":2,\"c\":3}",
  "application": "App",
  "schema": "some_schema_here",
  "true_timestamp": "1526584065167",
  "contexts": "[{\"schema\":\"another_schema_here\",\"message\":{\"j\":1,\"k\":2}}]",
  "@timestamp": "2018-05-17T19:07:45.167Z",
  "@version": "1",
  "severity": "INFO",
  "host": "Dominiks.local"
}
```